### PR TITLE
fix: Allow unsigned_integer to accept any value

### DIFF
--- a/lib/active_entity/type/unsigned_integer.rb
+++ b/lib/active_entity/type/unsigned_integer.rb
@@ -6,7 +6,7 @@ module ActiveEntity
       private
 
         def max_value
-          super * 2
+          ::Float::INFINITY
         end
 
         def min_value


### PR DESCRIPTION
Hi there! Im using @leastbad 's AllFutures gem and was doing some faceted search using AllFutures. I encountered a case where I wanted the max amount for something to be 100_000_000_000 and the minimum amount to be the negative amount.

Since ActiveEntity doesnt really account for `:bigint` would it be okay to have the `max_value` of an integer be `::Float::INFINITY` like in the Rails bigint type?

https://github.com/rails/rails/blob/83a4fa414bc9e5008825f47857fdd80e85c82033/activemodel/lib/active_model/type/big_integer.rb#L10

Error:

<img width="1332" alt="Screen Shot 2022-01-15 at 6 02 16 PM" src="https://user-images.githubusercontent.com/26425882/149640407-5aa144e7-c4e6-4a55-910b-d9a574f23779.png">


I can confirm monkey patching ActiveEntity locally fixes the error.